### PR TITLE
Exclude clojure.core/flush and clojure.core/send

### DIFF
--- a/src/gregor/core.clj
+++ b/src/gregor/core.clj
@@ -1,4 +1,5 @@
 (ns gregor.core
+  (:refer-clojure :exclude [flush send])
   (:import [org.apache.kafka.common TopicPartition]
            [org.apache.kafka.clients.consumer Consumer KafkaConsumer ConsumerRecords
             ConsumerRecord OffsetAndMetadata OffsetCommitCallback


### PR DESCRIPTION
Suppress the warnings, since there's no confusing usage of those functions in `gregor.core`.

I know this is trivial, but I'd rather not mix it with another PR I'm working on right now. :)