### PR TITLE
Fix warnings re replacing functions from clojure.core

### DIFF
--- a/src/gregor/core.clj
+++ b/src/gregor/core.clj
@@ -5,7 +5,8 @@
             ConsumerRebalanceListener]
            [org.apache.kafka.clients.producer Producer KafkaProducer Callback
             ProducerRecord RecordMetadata])
-  (:require [clojure.string :as str]))
+  (:require [clojure.string :as str])
+  (:refer-clojure :exclude [flush send]))
 
 
 (def ^:no-doc str-deserializer "org.apache.kafka.common.serialization.StringDeserializer")

--- a/test/gregor/core_test.clj
+++ b/test/gregor/core_test.clj
@@ -5,7 +5,8 @@
            [org.apache.kafka.clients.producer MockProducer]
            [org.apache.kafka.common TopicPartition]
            [org.apache.kafka.common.serialization StringSerializer]
-           [java.util ArrayList]))
+           [java.util ArrayList])
+  (:refer-clojure :exclude [flush send]))
 
 (deftest producing
   (let [p (MockProducer. true (StringSerializer.) (StringSerializer.))]


### PR DESCRIPTION
`flush` and `send` are functions which exist in clojure.core, so referring to the gregor.core namespace will cause the following warnings:

    WARNING: flush already refers to: #'clojure.core/flush in namespace: gregor.core, being replaced by: #'gregor.core/flush
    WARNING: send already refers to: #'clojure.core/send in namespace: gregor.core, being replaced by: #'gregor.core/send

This change excludes the relevant core fns from gregor.core.