### PR TITLE
Avoid a NullPointerException in the rebalance listener.

### DIFF
--- a/src/gregor/core.clj
+++ b/src/gregor/core.clj
@@ -54,9 +54,11 @@
   [assigned-cb revoked-cb]
   (reify ConsumerRebalanceListener
     (onPartitionsAssigned [this partitions]
-      (assigned-cb partitions))
+      (when assigned-cb
+        (assigned-cb partitions)))
     (onPartitionsRevoked [this partitions]
-      (revoked-cb partitions))))
+      (when revoked-cb
+        (revoked-cb partitions)))))
 
 (defn offset-and-metadata
   "Metadata for when an offset is committed."


### PR DESCRIPTION
If we subscribe to a topic and don't provide a `partitions-assigned-fn`
or a `partitions-revoked-fn` then we generate NullPointerExceptions.